### PR TITLE
Update version to 0.35.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-crt-cpp" %}
-{% set version = "0.34.0" %}
+{% set version = "0.35.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 159998cff5a52406eb486bf92989d2184dbf6d47d5ec2593b864625defac279b
+  sha256: 3deb29f816498259aa289930afdb5f37d95bba991ec224952f57f931d877e81d
   patches:
     - patches/0001-use-C-style-for-including-inttypes-in-bin-mqtt5_cana.patch
 
@@ -24,15 +24,15 @@ requirements:
     - cmake
     - ninja-base
   host:
-    - aws-c-auth 0.9.0
-    - aws-c-cal 0.9.2
-    - aws-checksums 0.2.7
-    - aws-c-common 0.12.4
-    - aws-c-event-stream 0.5.6
-    - aws-c-http 0.10.4
-    - aws-c-io 0.21.4
+    - aws-c-auth 0.9.4
+    - aws-c-cal 0.9.13
+    - aws-checksums 0.2.8
+    - aws-c-common 0.12.6
+    - aws-c-event-stream 0.5.9
+    - aws-c-http 0.10.7
+    - aws-c-io 0.23.3
     - aws-c-mqtt 0.13.3
-    - aws-c-s3 0.8.7
+    - aws-c-s3 0.11.3
     - aws-c-sdkutils 0.2.4
 test:
   commands:


### PR DESCRIPTION
aws-crt-cpp 0.35.4

**Destination channel:** defaults

### Links

- [PKG-11435](https://anaconda.atlassian.net/browse/PKG-11435) 
- [Upstream repository](https://github.com/awslabs/aws-crt-cpp/tree/v0.35.4#)

### Explanation of changes:

- New version number
- Updating dependencies


[PKG-11435]: https://anaconda.atlassian.net/browse/PKG-11435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ