### PR TITLE
aws-crt-cpp 0.37.4 - rebuild (new dependencies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-http-feedstock/pr7/c623fb1
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-auth-feedstock/pr7/15f9a47
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-mqtt-feedstock/pr7/772b912

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-http-feedstock/pr7/c623fb1
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-auth-feedstock/pr7/15f9a47
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-mqtt-feedstock/pr7/772b912
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-event-stream-feedstock/pr10/f10fc1d
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-s3-feedstock/pr8/f579a73
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,6 @@ channels:
   - https://staging.continuum.io/preprod-pbp/fs/aws-c-http-feedstock/pr7/c623fb1
   - https://staging.continuum.io/preprod-pbp/fs/aws-c-auth-feedstock/pr7/15f9a47
   - https://staging.continuum.io/preprod-pbp/fs/aws-c-mqtt-feedstock/pr7/772b912
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-event-stream-feedstock/pr10/f10fc1d
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-s3-feedstock/pr8/f579a73
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-use-C-style-for-including-inttypes-in-bin-mqtt5_cana.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-crt-cpp", max_pin="x.x.x") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,14 +24,14 @@ requirements:
     - cmake
     - ninja-base
   host:
-    - aws-c-auth 0.9.4
+    - aws-c-auth 0.10.1
     - aws-c-cal 0.9.13
     - aws-checksums 0.2.10
     - aws-c-common 0.12.6
-    - aws-c-event-stream 0.6.0
-    - aws-c-http 0.10.7
-    - aws-c-io 0.23.3
-    - aws-c-mqtt 0.13.3
+    - aws-c-event-stream 0.6.1
+    - aws-c-http 0.10.13
+    - aws-c-io 0.26.3
+    - aws-c-mqtt 0.15.2
     - aws-c-s3 0.12.0
     - aws-c-sdkutils 0.2.4
 test:


### PR DESCRIPTION
aws-crt-cpp 0.37.4 

**Destination channel:** Defaults

### Links

- [PKG-13656]
- dev_url:        https://github.com/awslabs/aws-crt-cpp
- conda_forge:    https://github.com/conda-forge/aws-crt-cpp-feedstock
- pypi:           https://pypi.org/project/aws-crt-cpp/0.37.4
- pypi inspector: https://inspector.pypi.io/project/aws-crt-cpp/0.37.4

### Explanation of changes:

- new version number


[PKG-13656]: https://anaconda.atlassian.net/browse/PKG-13656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ